### PR TITLE
update target sdk version to ICS for a cleaner menu bar

### DIFF
--- a/AndroidManifest.xml
+++ b/AndroidManifest.xml
@@ -6,7 +6,7 @@
 
     <uses-sdk
         android:minSdkVersion="8"
-        android:targetSdkVersion="8" />
+        android:targetSdkVersion="14" />
 
     <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
     <uses-permission android:name="android.permission.INTERNET" />


### PR DESCRIPTION
Updating the target version to SDK 14 or above (ICS) results in the newer, cleaner menu bar without the deprecated options menu and the compatibility zoom button.
