### PR TITLE
Update .factorypath with correct project name

### DIFF
--- a/.factorypath
+++ b/.factorypath
@@ -1,3 +1,3 @@
 <factorypath>
-    <factorypathentry kind="WKSPJAR" id="/HN-Android/androidannotations-2.5.jar" enabled="true" runInBatchMode="false"/>
+    <factorypathentry kind="WKSPJAR" id="/HNReader/androidannotations-2.5.jar" enabled="true" runInBatchMode="false"/>
 </factorypath>


### PR DESCRIPTION
Fixes "Unable to load annotation processor factory" issues when first loading in Eclipse.
