### PR TITLE
Fixing Issue #15

### DIFF
--- a/src/com/manuelmaly/hn/ArticleReaderActivity.java
+++ b/src/com/manuelmaly/hn/ArticleReaderActivity.java
@@ -174,6 +174,12 @@ public class ArticleReaderActivity extends Activity {
     	}
     }
 
+    @Override
+    protected void onDestroy() {
+    	super.onDestroy();
+    	mWebView.destroy(); //Destroy any players (e.g. Youtube, Soundcloud) if any
+    }
+
     private class HNReaderWebViewClient extends WebViewClient {
         @Override
         public boolean shouldOverrideUrlLoading(WebView view, String url) {


### PR DESCRIPTION
Fixed issue https://github.com/manmal/hn-android/issues/15
Upon destroying the Article activity, calling the destroy method for the WebView instance will kill any playings running such as YouTube and Soundcloud
