### PR TITLE
moved around jars in the build path

### DIFF
--- a/.classpath
+++ b/.classpath
@@ -2,6 +2,10 @@
 <classpath>
 	<classpathentry excluding="com/manuelmaly/hnreader/parser/OldHNFeedParser.java|com/manuelmaly/hnreader/parser/BaseHTMLStringListParser.java|com/manuelmaly/hnreader/parser/BaseHTMLIntListParser.java" kind="src" path="src"/>
 	<classpathentry kind="src" path="gen"/>
+	<classpathentry kind="lib" path="libs/android-support-v4.jar"/>
+	<classpathentry kind="lib" path="libs/androidannotations-2.5-api.jar"/>
+	<classpathentry kind="lib" path="libs/libGoogleAnalytics.jar"/>
+	<classpathentry kind="lib" path="libs/jsoup-1.6.3.jar"/>
 	<classpathentry kind="con" path="com.android.ide.eclipse.adt.ANDROID_FRAMEWORK"/>
 	<classpathentry kind="con" path="com.android.ide.eclipse.adt.LIBRARIES"/>
 	<classpathentry kind="src" path=".apt_generated">
@@ -9,9 +13,5 @@
 			<attribute name="optional" value="true"/>
 		</attributes>
 	</classpathentry>
-	<classpathentry kind="lib" path="libs/android-support-v4.jar"/>
-	<classpathentry kind="lib" path="libs/androidannotations-2.5-api.jar"/>
-	<classpathentry kind="lib" path="libs/libGoogleAnalytics.jar"/>
-	<classpathentry kind="lib" path="libs/jsoup-1.6.3.jar"/>
 	<classpathentry kind="output" path="bin/classes"/>
 </classpath>


### PR DESCRIPTION
I ran into some issues when trying to build and start the application in that I was getting NoClassDefFoundError exceptions being thrown whenever the application tried to grab a GA tracker instance.  After looking at [This StackOverflow post](http://stackoverflow.com/questions/8678630/noclassdeffounderror-android) I tried moving around the order in which the jars were being included.  Bumping the external jars above the android libraries did the trick and allowed me to build and run the hn app.

I have a suspicion this might have to do with the ADT version that I'm using, so for reference I'm using ADT 22.
