### PR TITLE
Fixed a comments parsing bug

### DIFF
--- a/src/com/manuelmaly/hn/parser/HNCommentsParser.java
+++ b/src/com/manuelmaly/hn/parser/HNCommentsParser.java
@@ -39,8 +39,12 @@ public class HNCommentsParser extends BaseHTMLParser<HNPostComments> {
             Element rowLevelElement = tableRows.get(row).select("td:eq(0)").first();
             if (mainRowElement == null)
                 break;
-            
-            text = mainRowElement.select("span.comment > *:not(*:contains(reply))").html();
+
+            // The not portion of this query is meant to remove the reply link
+            // from the text.  As far as I can tell that is the only place
+            // where size=1 is used.  If that turns out to not be the case then
+            // searching for u tags is also a pretty decent option - @jmaltz
+            text = mainRowElement.select("span.comment > *:not(:has(font[size=1]))").html();
 
             Element comHeadElement = mainRowElement.select("span.comhead").first();
             author = comHeadElement.select("a[href*=user]").text();


### PR DESCRIPTION
Before if the word "reply" was in a comment then it wouldn't be displayed because of how the query was setup.  This fixes that bug by looking for the <u> tag which wraps around the reply link.
