### PR TITLE
Fixed a bug where comments on Poll HN posts wouldn't render properly

### DIFF
--- a/src/com/manuelmaly/hn/parser/HNCommentsParser.java
+++ b/src/com/manuelmaly/hn/parser/HNCommentsParser.java
@@ -38,7 +38,7 @@ public class HNCommentsParser extends BaseHTMLParser<HNPostComments> {
             Element mainRowElement = tableRows.get(row).select("td:eq(2)").first();
             Element rowLevelElement = tableRows.get(row).select("td:eq(0)").first();
             if (mainRowElement == null)
-                break;
+                continue;
 
             // The not portion of this query is meant to remove the reply link
             // from the text.  As far as I can tell that is the only place


### PR DESCRIPTION
This is re: #69.  I couldn't figure out how to do this in the CSS selector (querying for tr:has(table td:eq(2)) instead of tr:has(table) gave me way more results than I wanted) and I don't see anything conceptually wrong with this solution.  I also have a feeling that this break statement is the cause of  #73, but I can't be sure.
