### PR TITLE
Fixed up a bug where newlines weren't getting properly inserted into comments

### DIFF
--- a/src/com/manuelmaly/hn/CommentsActivity.java
+++ b/src/com/manuelmaly/hn/CommentsActivity.java
@@ -49,6 +49,7 @@ import com.manuelmaly.hn.task.ITaskFinishedHandler;
 import com.manuelmaly.hn.util.DisplayHelper;
 import com.manuelmaly.hn.util.FileUtil;
 import com.manuelmaly.hn.util.FontHelper;
+import com.manuelmaly.hn.util.StringUtils;
 
 @EActivity(R.layout.comments_activity)
 public class CommentsActivity extends BaseListActivity implements ITaskFinishedHandler<HNPostComments> {
@@ -214,7 +215,8 @@ public class CommentsActivity extends BaseListActivity implements ITaskFinishedH
             mCommentHeaderText.setVisibility(View.VISIBLE);
             // We trip it here to get rid of pesky newlines that come from
             // closing <p> tags
-            mCommentHeaderText.setText(Html.fromHtml(comments.getHeaderHtml()).toString().trim());
+            mCommentHeaderText.setText(StringUtils.trimTrailingWhitespace(
+                    Html.fromHtml(comments.getHeaderHtml())));
             Linkify.addLinks(mCommentHeaderText,
                     Pattern.compile("(https?:\\/\\/)([\\da-z\\.-]+)\\.([a-z\\.]{2,6})([\\/\\w \\.-]*)*\\/?"), "");
         }
@@ -526,7 +528,8 @@ public class CommentsActivity extends BaseListActivity implements ITaskFinishedH
         public void setComment(HNComment comment, int commentLevelIndentPx, Context c, int commentTextSize,
             int metadataTextSize) {
             textView.setTextSize(TypedValue.COMPLEX_UNIT_DIP, commentTextSize);
-            textView.setText(Html.fromHtml(comment.getText()));
+            textView.setText(StringUtils.trimTrailingWhitespace(Html.fromHtml(
+                    comment.getText())));
             textView.setMovementMethod(LinkMovementMethod.getInstance());
             authorView.setTextSize(TypedValue.COMPLEX_UNIT_DIP, metadataTextSize);
             timeAgoView.setTextSize(TypedValue.COMPLEX_UNIT_DIP, metadataTextSize);

--- a/src/com/manuelmaly/hn/util/StringUtils.java
+++ b/src/com/manuelmaly/hn/util/StringUtils.java
@@ -1,0 +1,18 @@
+package com.manuelmaly.hn.util;
+
+public class StringUtils {
+
+    public static CharSequence trimTrailingWhitespace(CharSequence source) {
+
+        if(source == null)
+            return "";
+
+        int i = source.length();
+
+        // loop back to the first non-whitespace character
+        while(--i >= 0 && Character.isWhitespace(source.charAt(i))) {
+        }
+
+        return source.subSequence(0, i+1);
+    }
+}


### PR DESCRIPTION
This has been pissing me off for a while, and I finally realized it was because of how Hacker News embeds their HTML.  

Basically, what the structure is that at first there is a `<font>` tag wrapping a bunch of `<p>` tags, and then a set of `<p>` wrapping `<font>` tags.  Since the previous query just grabbed the direct children of the `.comment` element, this caused the latter type of comment to not have it's proper line breaks inserted because of how the `html` method in Jsoup works.  

Anyway, this should fix that problem by just grabbing all the `<font>` tags in the selector and then wrapping all but the first element in `<p>` tags, which is what the HN website basically does.
