### PR TITLE
Adding mark as read feature.

### DIFF
--- a/res/layout/main_list_item.xml
+++ b/res/layout/main_list_item.xml
@@ -23,7 +23,7 @@
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:text="@string/no_topic"
-            android:textColor="#262321"
+            android:textColor="@color/dark_gray_post_title"
             android:textSize="18sp"
             android:textStyle="bold" />
 

--- a/res/values/colors.xml
+++ b/res/values/colors.xml
@@ -6,4 +6,6 @@
     <color name="red_dark_washedout">#9e402c</color>
     <color name="gray_comments_information">#9c9186</color>
     <color name="gray_comments_divider">#b8ab9e</color>
+    <color name="dark_gray_post_title">#262321</color>
+    <color name="gray_post_title_read">#9a8e86</color>
 </resources>


### PR DESCRIPTION
Once a post is clicked, it is greyed out to give a visual feedback that it was read.
In order to have the read posts persisted, they are cached for 2 days within their own SharedPreferences. That should be sufficient time for the post to be removed from the feed. 

The cache is maintained each time the MainActivity is started and shouldn't become too large.
