### PR TITLE
Fixed comments caching

### DIFF
--- a/hn-android/src/com/manuelmaly/hn/CommentsActivity.java
+++ b/hn-android/src/com/manuelmaly/hn/CommentsActivity.java
@@ -275,7 +275,9 @@ public class CommentsActivity extends BaseListActivity implements
                     && result.getUserAcquiredFor() != null
                     && (!result.getUserAcquiredFor().equals(
                             Settings.getUserName(CommentsActivity.this)));
-            if (registeredUserChanged) {
+            // Only show comments if we last fetched them for the current user
+            // and we have comments
+            if (!registeredUserChanged && result != null) {
                 showComments(result);
             } else {
                 updateEmptyView();


### PR DESCRIPTION
This solves #99

A boolean parameter was being compared for the incorrect result to determine whether or not we would show comments.  This resulted in us not showing cached comments.

Testing done: 
Went to a page for the first time with the internet enabled: comments were properly loaded
Backed out, disabled internet, went back to that same post: cached comments appeared
Opened a set of comments with no internet: "no comments" appeared
Opened the same set with internet: comments were properly loaded
