### PR TITLE
loading more until the end of time

### DIFF
--- a/hn-android/src/com/manuelmaly/hn/MainActivity.java
+++ b/hn-android/src/com/manuelmaly/hn/MainActivity.java
@@ -216,10 +216,11 @@ public class MainActivity extends BaseListActivity implements
             supportInvalidateOptionsMenu();
         } else
             if (taskCode == TASKCODE_LOAD_MORE_POSTS) {
-                if (!code.equals(TaskResultCode.Success)) {
+                if (!code.equals(TaskResultCode.Success) || result == null || result.getPosts() == null || result.getPosts().size() == 0) {
                     Toast.makeText(this,
                             getString(R.string.error_unable_to_load_more),
                             Toast.LENGTH_SHORT).show();
+                  mFeed.setLoadedMore(true); // reached the end.
                 }
 
                 mFeed.appendLoadMoreFeed(result);

--- a/hn-android/src/com/manuelmaly/hn/model/HNFeed.java
+++ b/hn-android/src/com/manuelmaly/hn/model/HNFeed.java
@@ -46,8 +46,7 @@ public class HNFeed implements Serializable {
     public void appendLoadMoreFeed(HNFeed feed) {
         if (feed == null || feed.getPosts() == null)
             return;
-        
-        mLoadedMore = true;
+
         for (HNPost candidate : feed.getPosts())
             if (!mPosts.contains(candidate))
                 mPosts.add(candidate);
@@ -56,6 +55,10 @@ public class HNFeed implements Serializable {
     
     public boolean isLoadedMore() {
         return mLoadedMore;
+    }
+
+    public void setLoadedMore(boolean loadedMore) {
+      mLoadedMore = loadedMore;
     }
     
     public String getUserAcquiredFor() {

--- a/hn-android/src/com/manuelmaly/hn/server/BaseHTTPCommand.java
+++ b/hn-android/src/com/manuelmaly/hn/server/BaseHTTPCommand.java
@@ -175,7 +175,7 @@ public abstract class BaseHTTPCommand<T extends Serializable> implements IAPICom
     }
 
     protected String getUrlWithParams() {
-        return mUrl + (mURLQueryParams != null ? "?" + mURLQueryParams : "");
+        return mUrl + (mURLQueryParams != null && !mURLQueryParams.equals("") ? "?" + mURLQueryParams : "");
     }
 
     public void responseHandlingFinished(T parsedResponse, int responseHttpStatus) {


### PR DESCRIPTION
addressing issue #148 #146 

The more button loads until all old articles are shown within the list.
Note, that the refresh button will reset to the initial state and show only the front page.