### PR TITLE
caching comments for articles where the total count is less than 150

### DIFF
--- a/hn-android/src/com/manuelmaly/hn/util/FileUtil.java
+++ b/hn-android/src/com/manuelmaly/hn/util/FileUtil.java
@@ -4,15 +4,18 @@ import android.os.AsyncTask;
 import android.util.Log;
 
 import com.manuelmaly.hn.App;
+import com.manuelmaly.hn.model.HNCommentTreeNode;
 import com.manuelmaly.hn.model.HNFeed;
 import com.manuelmaly.hn.model.HNPostComments;
 
+import java.io.BufferedOutputStream;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.ObjectInputStream;
 import java.io.ObjectOutputStream;
+import java.util.List;
 
 public class FileUtil {
 
@@ -116,8 +119,12 @@ public class FileUtil {
             public void run() {
                 ObjectOutputStream os = null;
                 try {
-                    os = new ObjectOutputStream(new FileOutputStream(getLastHNPostCommentsPath(postID)));
-                    os.writeObject(comments);
+                  int nodesCount = countNodes(comments.getTreeNodes());
+                  if (nodesCount > 150) {
+                    return;
+                  }
+                  os = new ObjectOutputStream(new FileOutputStream(getLastHNPostCommentsPath(postID)));
+                  os.writeObject(comments);
                 } catch (Exception e) {
                     Log.e(TAG, "Could not save last HNPostComments to file :(", e);
                 } finally {
@@ -137,5 +144,19 @@ public class FileUtil {
         File dataDir = App.getInstance().getFilesDir();
         return dataDir.getAbsolutePath() + "/" + LAST_HNPOSTCOMMENTS_FILENAME_PREFIX + "_" + postID;
     }
+
+  private static int countNodes(List<HNCommentTreeNode> nodes) {
+    int sum = 0;
+
+    if (nodes != null) {
+      sum += nodes.size();
+
+      for (HNCommentTreeNode n : nodes) {
+        sum += countNodes(n.getChildren());
+      }
+    }
+
+    return sum;
+  }
 
 }


### PR DESCRIPTION
Adding a work around for articles with many comments which cause the app the crash.
The problem is that the current serialisation method writes the whole objects to a file instead of employing different serialisation strategies.

This causes the ObjectOutputStream.writeObject to throw a StackOverflowError due to the current model of the comments.

I tested a bit and it seems this happens for articles where the total comment count is > 150.
As most of the articles have less comments anyway, this should be fine for now.

However, we will have to fix this properly in version 2.