### PR TITLE
Remove trailing space in multi-paragraph comments

### DIFF
--- a/hn-android/src/com/manuelmaly/hn/parser/HNCommentsParser.java
+++ b/hn-android/src/com/manuelmaly/hn/parser/HNCommentsParser.java
@@ -50,7 +50,12 @@ public class HNCommentsParser extends BaseHTMLParser<HNPostComments> {
 
             mainCommentSpan.select("div.reply").remove();
 
-            text = mainCommentSpan.html().replace("<span> </span>", "");
+            // In order to eliminate whitespace at the end of multi-line comments,
+            // <p> tags are replaced with double <br/> tags.
+            text = mainCommentSpan.html()
+                     .replace("<span> </span>", "")
+                     .replace("<p>", "<br/><br/>")
+                     .replace("</p>", "");
 
             Element comHeadElement = mainRowElement.select("span.comhead").first();
             author = comHeadElement.select("a[href*=user]").text();


### PR DESCRIPTION
This change fixes an issue where multi-paragraph comments have some extra space after the comment. This happens because the last paragraph is wrapped in a `<p>` element. You can see this happening in mcv's comment below.

![hn-before](https://cloud.githubusercontent.com/assets/8731922/9787332/c9faeaba-57fc-11e5-8e60-ba936e177d53.png)

This pull request changes the `HNCommentsParser` class so that closing `</p>` tags in the comment HTML are replaced with `<br/><br/>`, and opening `<p>` tags are removed. This way, there is a double space between each of the paragraphs, and no spacing after.

![hn-after](https://cloud.githubusercontent.com/assets/8731922/9787348/f5dc3a58-57fc-11e5-8b79-ff98b67e2520.png)