### PR TITLE
Show the correct comment color

### DIFF
--- a/hn-android/build.gradle
+++ b/hn-android/build.gradle
@@ -19,6 +19,9 @@ dependencies {
 }
 
 android {
+    compileOptions {
+        encoding "UTF-8"
+    }
     compileSdkVersion 19
     buildToolsVersion '19.1.0'
     sourceSets {

--- a/hn-android/src/com/manuelmaly/hn/CommentsActivity.java
+++ b/hn-android/src/com/manuelmaly/hn/CommentsActivity.java
@@ -658,6 +658,7 @@ public class CommentsActivity extends BaseListActivity implements
         public void setComment(HNComment comment, int commentLevelIndentPx,
                 Context c, int commentTextSize, int metadataTextSize) {
             textView.setTextSize(TypedValue.COMPLEX_UNIT_DIP, commentTextSize);
+            textView.setTextColor(comment.getColor());
             textView.setText(Html.fromHtml(comment.getText()));
             textView.setMovementMethod(LinkMovementMethod.getInstance());
             authorView.setTextSize(TypedValue.COMPLEX_UNIT_DIP,

--- a/hn-android/src/com/manuelmaly/hn/model/HNComment.java
+++ b/hn-android/src/com/manuelmaly/hn/model/HNComment.java
@@ -9,19 +9,21 @@ public class HNComment implements Serializable {
     private String mAuthor;
     private String mCommentLink;
     private String mText;
+    private int mColor;
     private String mUpvoteUrl;
     private String mDownvoteUrl;
     private int mCommentLevel;
     private boolean mDownvoted;
     private HNCommentTreeNode mTreeNode;
 
-    public HNComment(String timeAgo, String author, String commentLink, String text, int commentLevel, boolean downvoted, String upvoteUrl,
+    public HNComment(String timeAgo, String author, String commentLink, String text, int color, int commentLevel, boolean downvoted, String upvoteUrl,
                 String downvoteUrl) {
         super();
         mTimeAgo = timeAgo;
         mAuthor = author;
         mCommentLink = commentLink;
         mText = text;
+        mColor = color;
         mCommentLevel = commentLevel;
         mDownvoted = downvoted;
         mUpvoteUrl = upvoteUrl;
@@ -42,6 +44,10 @@ public class HNComment implements Serializable {
 
     public String getText() {
         return mText;
+    }
+
+    public int getColor() {
+        return mColor;
     }
 
     public boolean isDownvoted() {

--- a/hn-android/src/com/manuelmaly/hn/parser/HNCommentsParser.java
+++ b/hn-android/src/com/manuelmaly/hn/parser/HNCommentsParser.java
@@ -1,5 +1,7 @@
 package com.manuelmaly.hn.parser;
 
+import android.graphics.Color;
+
 import com.manuelmaly.hn.App;
 import com.manuelmaly.hn.Settings;
 import com.manuelmaly.hn.model.HNComment;
@@ -50,12 +52,18 @@ public class HNCommentsParser extends BaseHTMLParser<HNPostComments> {
 
             mainCommentSpan.select("div.reply").remove();
 
+            // Parse the class attribute to get the comment color
+            int commentColor = Color.rgb(0, 0, 0);
+            if (mainCommentSpan.attributes().hasKey("class")) {
+                commentColor = getCommentColor(mainCommentSpan.attributes().get("class"));
+            }
+
             // In order to eliminate whitespace at the end of multi-line comments,
             // <p> tags are replaced with double <br/> tags.
             text = mainCommentSpan.html()
-                     .replace("<span> </span>", "")
-                     .replace("<p>", "<br/><br/>")
-                     .replace("</p>", "");
+                    .replace("<span> </span>", "")
+                    .replace("<p>", "<br/><br/>")
+                    .replace("</p>", "");
 
             Element comHeadElement = mainRowElement.select("span.comhead").first();
             author = comHeadElement.select("a[href*=user]").text();
@@ -76,9 +84,9 @@ public class HNCommentsParser extends BaseHTMLParser<HNPostComments> {
             // We want to test for size because unlike first() calling .get(1)
             // Will throw an error if there are not two elements
             if (voteElements.size() > 1)
-               downvoteUrl = getVoteUrl(voteElements.get(1));
+                downvoteUrl = getVoteUrl(voteElements.get(1));
 
-            comments.add(new HNComment(timeAgo, author, url, text, level, isDownvoted, upvoteUrl, downvoteUrl));
+            comments.add(new HNComment(timeAgo, author, url, text, commentColor, level, isDownvoted, upvoteUrl, downvoteUrl));
 
             if (endParsing)
                 break;
@@ -92,10 +100,11 @@ public class HNCommentsParser extends BaseHTMLParser<HNPostComments> {
         // Five table rows is what it takes for the title, post information
         // And other boilerplate stuff.  More than five means we have something
         // Special
-        if(header.select("tr").size() > 5) {
+        if (header.select("tr").size() > 5) {
             HeaderParser headerParser = new HeaderParser();
             headerHtml = headerParser.parseDocument(header);
         }
+
 
         return new HNPostComments(comments, headerHtml, currentUser);
     }
@@ -114,4 +123,27 @@ public class HNCommentsParser extends BaseHTMLParser<HNPostComments> {
         return null;
     }
 
+    private int getCommentColor(String className) {
+        if ("c5a".equals(className)) {
+            return Color.rgb(0x5A, 0x5A, 0x5A);
+        } else if ("c73".equals(className)) {
+            return Color.rgb(0x73, 0x73, 0x73);
+        } else if ("c82".equals(className)) {
+            return Color.rgb(0x82, 0x82, 0x82);
+        } else if ("c88".equals(className)) {
+            return Color.rgb(0x88, 0x88, 0x88);
+        } else if ("c9c".equals(className)) {
+            return Color.rgb(0x9C, 0x9C, 0x9C);
+        } else if ("cae".equals(className)) {
+            return Color.rgb(0xAE, 0xAE, 0xAE);
+        } else if ("cbe".equals(className)) {
+            return Color.rgb(0xBE, 0xBE, 0xBE);
+        } else if ("cce".equals(className)) {
+            return Color.rgb(0xCE, 0xCE, 0xCE);
+        } else if ("cdd".equals(className)) {
+            return Color.rgb(0xDD, 0xDD, 0xDD);
+        } else {
+            return Color.rgb(0, 0, 0);
+        }
+    }
 }


### PR DESCRIPTION
This PR parses the comment class attribute and use the correct color.

The colors are based on https://news.ycombinator.com/news.css.

Here's how it looks:

![device-2015-10-17-200255](https://cloud.githubusercontent.com/assets/1916079/10560400/90911e7c-750a-11e5-9c7a-b92d6b4acfb3.png)
