### PR TITLE
Some intent updates.

### DIFF
--- a/hn-android/AndroidManifest.xml
+++ b/hn-android/AndroidManifest.xml
@@ -57,6 +57,10 @@
                     android:host="news.ycombinator.com"
                     android:scheme="https" >
                 </data>
+                <data
+                    android:host="news.ycombinator.com"
+                    android:scheme="http" >
+                </data>
             </intent-filter>
         </activity>
         <activity android:name=".login.LoginActivity_" android:label="@string/credentials" android:theme="@android:style/Theme.Dialog" />

--- a/hn-android/AndroidManifest.xml
+++ b/hn-android/AndroidManifest.xml
@@ -34,20 +34,12 @@
             android:configChanges="keyboardHidden|orientation|screenSize"
             android:exported="false"
             android:theme="@style/ActionBar.White">
-            <intent-filter>
-                <action android:name="android.intent.action.SEND" />
-                <data android:mimeType="text/plain" />
-            </intent-filter>
         </activity>
         <activity
             android:name=".CommentsActivity_"
             android:configChanges="keyboardHidden|orientation|screenSize"
             android:exported="false"
             android:theme="@style/ActionBar.Orange.Back">
-            <intent-filter>
-                <action android:name="android.intent.action.SEND" />
-                <data android:mimeType="text/plain" />
-            </intent-filter>
         </activity>
         <activity android:name=".SettingsActivity"
             android:theme="@android:style/Theme.Light.NoTitleBar"

--- a/hn-android/AndroidManifest.xml
+++ b/hn-android/AndroidManifest.xml
@@ -23,11 +23,6 @@
                 <action android:name="android.intent.action.MAIN" />
                 <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
-            <intent-filter>
-                <action android:name="android.intent.action.SEND" />
-                <category android:name="android.intent.category.BROWSABLE" />
-                <data android:mimeType="text/plain" />
-            </intent-filter>
         </activity>
         <activity
             android:name="ArticleReaderActivity_"

--- a/hn-android/AndroidManifest.xml
+++ b/hn-android/AndroidManifest.xml
@@ -62,6 +62,11 @@
                     android:scheme="http" >
                 </data>
             </intent-filter>
+            <intent-filter>
+                <action android:name="android.intent.action.SEND" />
+                <category android:name="android.intent.category.BROWSABLE" />
+                <data android:mimeType="text/plain" />
+            </intent-filter>
         </activity>
         <activity android:name=".login.LoginActivity_" android:label="@string/credentials" android:theme="@android:style/Theme.Dialog" />
     </application>

--- a/hn-android/src/com/manuelmaly/hn/CommentsActivity.java
+++ b/hn-android/src/com/manuelmaly/hn/CommentsActivity.java
@@ -249,6 +249,14 @@ public class CommentsActivity extends BaseListActivity implements
     public void onTaskFinished(int taskCode, TaskResultCode code,
             HNPostComments result, Object tag) {
         if (code.equals(TaskResultCode.Success) && mCommentsListAdapter != null) {
+
+            //If there isn't an article URL, use the one pulled out during comments page parsing
+            //This is used if the comments page was loaded externally (article URI is normally
+            // set when parsing the main page otherwise).
+            if(result.getArticleUrl() != null && mPost.getURL() == null ) {
+                mPost.setURL( result.getArticleUrl());
+            }
+
             showComments(result);
         } else
             if (!code.equals(TaskResultCode.Success)) {

--- a/hn-android/src/com/manuelmaly/hn/ExternalIntentActivity.java
+++ b/hn-android/src/com/manuelmaly/hn/ExternalIntentActivity.java
@@ -10,21 +10,39 @@ import android.widget.Toast;
 
 public class ExternalIntentActivity extends Activity {
 
+  private Uri getURIFromIntent( Intent intent ) {
+
+    // Only handle the two expected intents
+    if( intent.getAction().equals(Intent.ACTION_SEND)) {
+      return Uri.parse( intent.getStringExtra(Intent.EXTRA_TEXT) );
+    } else if( intent.getAction().equals(Intent.ACTION_VIEW)) {
+      return getIntent().getData();
+    }
+    return null; //otherwise null, to be handled later.
+  }
+
   @Override
   protected void onCreate(Bundle savedInstanceState) {
     super.onCreate(savedInstanceState);
 
-    Uri uri = getIntent().getData();
-    String uriString = uri.toString().replaceAll("/$", "");
+    // Handle both intents, get just the URI
+    Uri uri = getURIFromIntent( getIntent() );
 
+    // Intent to launch next activity.
     Intent i = null;
-    if (uriString.endsWith("news.ycombinator.com")) { // Front page
-      i = new Intent(this, MainActivity_.class);
-    } else if (uriString.contains("item")) { // Comment
-      String postId = uri.getQueryParameter("id");
-      HNPost postToOpen = new HNPost(uriString, null, null, null, postId, 0, 0, null);
-      i = new Intent(this, CommentsActivity_.class);
-      i.putExtra(CommentsActivity.EXTRA_HNPOST, postToOpen);
+
+    // Decide what to do based on the URI
+    if( uri != null ) {
+      String uriString = uri.toString().replaceAll("/$", "");
+
+      if (uriString.endsWith("news.ycombinator.com")) { // Front page
+        i = new Intent(this, MainActivity_.class);
+      } else if (uriString.contains("item")) { // Comment
+        String postId = uri.getQueryParameter("id");
+        HNPost postToOpen = new HNPost(uriString, null, null, null, postId, 0, 0, null);
+        i = new Intent(this, CommentsActivity_.class);
+        i.putExtra(CommentsActivity.EXTRA_HNPOST, postToOpen);
+      }
     }
 
     if (i != null) {

--- a/hn-android/src/com/manuelmaly/hn/ExternalIntentActivity.java
+++ b/hn-android/src/com/manuelmaly/hn/ExternalIntentActivity.java
@@ -18,18 +18,20 @@ public class ExternalIntentActivity extends Activity {
     String uriString = uri.toString().replaceAll("/$", "");
 
     Intent i = null;
-
-    // Should always be a comment link
-    if (uriString.contains("item")) {
+    if (uriString.endsWith("news.ycombinator.com")) { // Front page
+      i = new Intent(this, MainActivity_.class);
+    } else if (uriString.contains("item")) { // Comment
       String postId = uri.getQueryParameter("id");
       HNPost postToOpen = new HNPost(uriString, null, null, null, postId, 0, 0, null);
       i = new Intent(this, CommentsActivity_.class);
       i.putExtra(CommentsActivity.EXTRA_HNPOST, postToOpen);
+    }
+
+    if (i != null) {
+
       startActivity(i);
+
     } else {
-      // else load the front page
-      i = new Intent(this, MainActivity_.class);
-      startActivity(i);
       Toast.makeText(this, "This seems not to be a valid Hacker News item!", Toast.LENGTH_LONG).show();
     }
 

--- a/hn-android/src/com/manuelmaly/hn/ExternalIntentActivity.java
+++ b/hn-android/src/com/manuelmaly/hn/ExternalIntentActivity.java
@@ -39,7 +39,7 @@ public class ExternalIntentActivity extends Activity {
         i = new Intent(this, MainActivity_.class);
       } else if (uriString.contains("item")) { // Comment
         String postId = uri.getQueryParameter("id");
-        HNPost postToOpen = new HNPost(uriString, null, null, null, postId, 0, 0, null);
+        HNPost postToOpen = new HNPost( postId );
         i = new Intent(this, CommentsActivity_.class);
         i.putExtra(CommentsActivity.EXTRA_HNPOST, postToOpen);
       }

--- a/hn-android/src/com/manuelmaly/hn/ExternalIntentActivity.java
+++ b/hn-android/src/com/manuelmaly/hn/ExternalIntentActivity.java
@@ -18,20 +18,18 @@ public class ExternalIntentActivity extends Activity {
     String uriString = uri.toString().replaceAll("/$", "");
 
     Intent i = null;
-    if (uriString.endsWith("news.ycombinator.com")) { // Front page
-      i = new Intent(this, MainActivity_.class);
-    } else if (uriString.contains("item")) { // Comment
+
+    // Should always be a comment link
+    if (uriString.contains("item")) {
       String postId = uri.getQueryParameter("id");
       HNPost postToOpen = new HNPost(uriString, null, null, null, postId, 0, 0, null);
       i = new Intent(this, CommentsActivity_.class);
       i.putExtra(CommentsActivity.EXTRA_HNPOST, postToOpen);
-    }
-
-    if (i != null) {
-
       startActivity(i);
-
     } else {
+      // else load the front page
+      i = new Intent(this, MainActivity_.class);
+      startActivity(i);
       Toast.makeText(this, "This seems not to be a valid Hacker News item!", Toast.LENGTH_LONG).show();
     }
 

--- a/hn-android/src/com/manuelmaly/hn/model/HNPost.java
+++ b/hn-android/src/com/manuelmaly/hn/model/HNPost.java
@@ -26,9 +26,23 @@ public class HNPost implements Serializable {
         mUpvoteURL = upvoteURL;
     }
 
+    public HNPost( String postID ) {
+        super();
+        mURL = null;
+        mTitle = null;
+        mURLDomain = null;
+        mAuthor = null;
+        mPostID = postID;
+        mCommentsCount = 0;
+        mPoints = 0;
+        mUpvoteURL = null;
+    }
+
     public String getURL() {
         return mURL;
     }
+
+    public void setURL( String url ) { mURL = url; }
 
     public String getTitle() {
         return mTitle;

--- a/hn-android/src/com/manuelmaly/hn/model/HNPostComments.java
+++ b/hn-android/src/com/manuelmaly/hn/model/HNPostComments.java
@@ -12,16 +12,17 @@ public class HNPostComments implements Serializable {
     private boolean mIsTreeDirty;
     private String mHeaderHtml;
     private String mUserAcquiredFor;
+    private String mArticleUrl;
 
     public HNPostComments() {
         mTreeNodes = new ArrayList<HNCommentTreeNode>();
     }
 
     public HNPostComments(List<HNComment> comments) {
-        this(comments, null, "");
+        this(comments, null, "", null);
     }
 
-    public HNPostComments(List<HNComment> comments, String headerHtml, String userAcquiredFor) {
+    public HNPostComments(List<HNComment> comments, String headerHtml, String userAcquiredFor, String articleUrl) {
         mTreeNodes = new ArrayList<HNCommentTreeNode>();
         for (HNComment comment : comments) {
             if (comment.getCommentLevel() == 0)
@@ -29,6 +30,7 @@ public class HNPostComments implements Serializable {
         }
         mHeaderHtml = headerHtml;
         mUserAcquiredFor = userAcquiredFor;
+        mArticleUrl = articleUrl;
     }
 
     public List<HNCommentTreeNode> getTreeNodes() {
@@ -52,6 +54,8 @@ public class HNPostComments implements Serializable {
     public String getHeaderHtml() {
         return mHeaderHtml;
     }
+
+    public String getArticleUrl() { return mArticleUrl; }
 
     public String getUserAcquiredFor() {
         return mUserAcquiredFor;

--- a/hn-android/src/com/manuelmaly/hn/parser/HNCommentsParser.java
+++ b/hn-android/src/com/manuelmaly/hn/parser/HNCommentsParser.java
@@ -34,9 +34,17 @@ public class HNCommentsParser extends BaseHTMLParser<HNPostComments> {
         Boolean isDownvoted = false;
         String upvoteUrl = null;
         String downvoteUrl = null;
+        String articleUrl = null;
+
+        // Get the article URL
+        // Used when loading the comments page from an external intent
+        // URL is normally set when parsing the main page but not when
+        //  comments is loaded from external intent.
+        articleUrl = doc.select(".title a[href]").first().attr("href");
 
         boolean endParsing = false;
         for (int row = 0; row < tableRows.size(); row++) {
+
             Element mainRowElement = tableRows.get(row).select("td:eq(2)").first();
             Element rowLevelElement = tableRows.get(row).select("td:eq(0)").first();
             if (mainRowElement == null)
@@ -105,8 +113,7 @@ public class HNCommentsParser extends BaseHTMLParser<HNPostComments> {
             headerHtml = headerParser.parseDocument(header);
         }
 
-
-        return new HNPostComments(comments, headerHtml, currentUser);
+        return new HNPostComments(comments, headerHtml, currentUser, articleUrl);
     }
 
     /**


### PR DESCRIPTION
Hi,

I was looking at issue #158 and decided to try and fix it. I found out that having an intent-filter exposes an activity externally even with exported=false. Removing them fixes the issue and everything still works as normal.

The second thing in this PR is removing HN from the 'share' menu. I noticed that it didn't work so I was going to try and fix it. However, I realised that it's probably not needed as the user can't actually post using this app (and any links they click on should be picked up by the VIEW intent and sent to the app anyway rather than using the SEND intent).

Update: Also added http links to the intent. Links on the actual website will be https but other links could be http (probably fixes #166).

Update: reverted a commit that introduced a small bug ("not valid" message shown when loading HN homepage from external link).

Let me know what you think :).