### PR TITLE
Dismiss longtouch dialog on touch outside

### DIFF
--- a/hn-android/src/com/manuelmaly/hn/CommentsActivity.java
+++ b/hn-android/src/com/manuelmaly/hn/CommentsActivity.java
@@ -1,6 +1,7 @@
 package com.manuelmaly.hn;
 
 import android.app.AlertDialog;
+import android.app.Dialog;
 import android.content.Context;
 import android.content.DialogInterface;
 import android.content.Intent;
@@ -653,7 +654,10 @@ public class CommentsActivity extends BaseListActivity implements
                             CommentsActivity.this);
                     LongPressMenuListAdapter adapter = new LongPressMenuListAdapter(
                             comment);
-                    builder.setAdapter(adapter, adapter).show();
+                    builder.setAdapter(adapter, adapter);
+                    Dialog dialog = builder.create();
+                    dialog.setCanceledOnTouchOutside(true);
+                    dialog.show();
                     return true;
                 }
             });

--- a/hn-android/src/com/manuelmaly/hn/MainActivity.java
+++ b/hn-android/src/com/manuelmaly/hn/MainActivity.java
@@ -521,8 +521,6 @@ public class MainActivity extends BaseListActivity implements
                                 LongPressMenuListAdapter adapter = new LongPressMenuListAdapter(
                                         post);
                                 builder.setAdapter(adapter, adapter);
-
-
                                 Dialog dialog = builder.create();
                                 dialog.setCanceledOnTouchOutside(true);
                                 dialog.show();

--- a/hn-android/src/com/manuelmaly/hn/MainActivity.java
+++ b/hn-android/src/com/manuelmaly/hn/MainActivity.java
@@ -19,6 +19,7 @@ import org.androidannotations.annotations.ViewById;
 
 import android.app.Activity;
 import android.app.AlertDialog;
+import android.app.Dialog;
 import android.app.ProgressDialog;
 import android.content.Context;
 import android.content.DialogInterface;
@@ -519,7 +520,12 @@ public class MainActivity extends BaseListActivity implements
                                         MainActivity.this);
                                 LongPressMenuListAdapter adapter = new LongPressMenuListAdapter(
                                         post);
-                                builder.setAdapter(adapter, adapter).show();
+                                builder.setAdapter(adapter, adapter);
+
+
+                                Dialog dialog = builder.create();
+                                dialog.setCanceledOnTouchOutside(true);
+                                dialog.show();
                                 return true;
                             }
                         });


### PR DESCRIPTION
When you touch outside of a context menu displayed by long-touching an article on the main page, the context menu will now be dismissed.