### PR TITLE
enforces https for article viewers, removes outdated article readers, adds textise provider

### DIFF
--- a/app/src/main/java/com/manuelmaly/hn/ArticleReaderActivity.java
+++ b/app/src/main/java/com/manuelmaly/hn/ArticleReaderActivity.java
@@ -43,6 +43,7 @@ public class ArticleReaderActivity extends AppCompatActivity {
   public static final String EXTRA_HTMLPROVIDER_OVERRIDE = "HTMLPROVIDER_OVERRIDE";
 
   private static final String HTMLPROVIDER_PREFIX_INSTAPAPER = "https://www.instapaper.com/text?u=";
+  private static final String HTMLPROVIDER_PRFIX_TEXTISE = "https://www.textise.net/showText.aspx?strURL=";
 
   @ViewById(R.id.article_webview)
   WebView mWebView;
@@ -184,9 +185,11 @@ public class ArticleReaderActivity extends AppCompatActivity {
 
   @SuppressWarnings("deprecation")
   public static String getArticleViewURL( HNPost post, String htmlProvider, Context c ) {
-    String encodedURL = URLEncoder.encode( post.getURL() );
-    if (htmlProvider.equals( c.getString( R.string.pref_htmlprovider_instapaper ) )) {
+    String encodedURL = URLEncoder.encode(post.getURL());
+    if (htmlProvider.equals(c.getString(R.string.pref_htmlprovider_instapaper))) {
       return HTMLPROVIDER_PREFIX_INSTAPAPER + encodedURL;
+    } else if (htmlProvider.equals(c.getString(R.string.pref_htmlprovider_textise))){
+      return HTMLPROVIDER_PRFIX_TEXTISE + encodedURL;
     } else {
       return post.getURL();
     }

--- a/app/src/main/java/com/manuelmaly/hn/ArticleReaderActivity.java
+++ b/app/src/main/java/com/manuelmaly/hn/ArticleReaderActivity.java
@@ -42,9 +42,7 @@ public class ArticleReaderActivity extends AppCompatActivity {
   public static final String EXTRA_HNPOST = "HNPOST";
   public static final String EXTRA_HTMLPROVIDER_OVERRIDE = "HTMLPROVIDER_OVERRIDE";
 
-  private static final String HTMLPROVIDER_PREFIX_VIEWTEXT = "http://viewtext.org/article?url=";
-  private static final String HTMLPROVIDER_PREFIX_GOOGLE = "http://www.google.com/gwt/x?u=";
-  private static final String HTMLPROVIDER_PREFIX_INSTAPAPER = "http://www.instapaper.com/text?u=";
+  private static final String HTMLPROVIDER_PREFIX_INSTAPAPER = "https://www.instapaper.com/text?u=";
 
   @ViewById(R.id.article_webview)
   WebView mWebView;
@@ -187,11 +185,7 @@ public class ArticleReaderActivity extends AppCompatActivity {
   @SuppressWarnings("deprecation")
   public static String getArticleViewURL( HNPost post, String htmlProvider, Context c ) {
     String encodedURL = URLEncoder.encode( post.getURL() );
-    if (htmlProvider.equals( c.getString( R.string.pref_htmlprovider_viewtext ) )) {
-      return HTMLPROVIDER_PREFIX_VIEWTEXT + encodedURL;
-    } else if (htmlProvider.equals( c.getString( R.string.pref_htmlprovider_google ) )) {
-      return HTMLPROVIDER_PREFIX_GOOGLE + encodedURL;
-    } else if (htmlProvider.equals( c.getString( R.string.pref_htmlprovider_instapaper ) )) {
+    if (htmlProvider.equals( c.getString( R.string.pref_htmlprovider_instapaper ) )) {
       return HTMLPROVIDER_PREFIX_INSTAPAPER + encodedURL;
     } else {
       return post.getURL();

--- a/app/src/main/java/com/manuelmaly/hn/MainActivity.java
+++ b/app/src/main/java/com/manuelmaly/hn/MainActivity.java
@@ -604,8 +604,10 @@ public class MainActivity extends BaseListActivity implements
             mItems.addAll(Arrays.asList(
                     getString(R.string.pref_htmlprovider_original_url),
                     getString(R.string.pref_htmlprovider_instapaper),
+                    getString(R.string.pref_htmlprovider_textise),
                     getString(R.string.external_browser),
-                    getString(R.string.share_article_url)));
+                    getString(R.string.share_article_url)
+            ));
         }
 
         @Override

--- a/app/src/main/java/com/manuelmaly/hn/MainActivity.java
+++ b/app/src/main/java/com/manuelmaly/hn/MainActivity.java
@@ -603,8 +603,6 @@ public class MainActivity extends BaseListActivity implements
             }
             mItems.addAll(Arrays.asList(
                     getString(R.string.pref_htmlprovider_original_url),
-                    getString(R.string.pref_htmlprovider_viewtext),
-                    getString(R.string.pref_htmlprovider_google),
                     getString(R.string.pref_htmlprovider_instapaper),
                     getString(R.string.external_browser),
                     getString(R.string.share_article_url)));

--- a/app/src/main/res/values/preference_values.xml
+++ b/app/src/main/res/values/preference_values.xml
@@ -16,14 +16,10 @@
     <string name="pref_title_htmlprovider">View Articles via &#8230;</string>
     <string name="pref_default_htmlprovider">Original Article URL</string>
     <string name="pref_htmlprovider_original_url">Original Article URL</string>
-    <string name="pref_htmlprovider_viewtext">ViewText.org</string>
-    <string name="pref_htmlprovider_google">Google for Mobile Devices</string>
     <string name="pref_htmlprovider_instapaper">Instapaper Text</string>
 
     <string-array name="pref_array_htmlprovider">
         <item>@string/pref_htmlprovider_original_url</item>
-        <item>@string/pref_htmlprovider_viewtext</item>
-        <item>@string/pref_htmlprovider_google</item>
         <item>@string/pref_htmlprovider_instapaper</item>
     </string-array>
 

--- a/app/src/main/res/values/preference_values.xml
+++ b/app/src/main/res/values/preference_values.xml
@@ -17,10 +17,12 @@
     <string name="pref_default_htmlprovider">Original Article URL</string>
     <string name="pref_htmlprovider_original_url">Original Article URL</string>
     <string name="pref_htmlprovider_instapaper">Instapaper Text</string>
+    <string name="pref_htmlprovider_textise">Textise</string>
 
     <string-array name="pref_array_htmlprovider">
         <item>@string/pref_htmlprovider_original_url</item>
         <item>@string/pref_htmlprovider_instapaper</item>
+        <item>@string/pref_htmlprovider_textise</item>
     </string-array>
 
     <string name="pref_title_htmlviewer">View Articles within &#8230;</string>


### PR DESCRIPTION
- As they are no more supported, removes outdated article readers such as
1. google gwt
 2. view text

- makes https endpoint for instapaper provider as http are no longer supported.
- adds textize provider