### PR TITLE
Allow Http links to be opened on api level 28

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -8,7 +8,9 @@
     <application
         android:name=".App_"
         android:icon="@drawable/ic_launcher"
-        android:allowBackup="true" >
+        android:usesCleartextTraffic="true"
+        android:allowBackup="true"
+        tools:ignore="UnusedAttribute">
 
         <uses-library
             android:name="org.apache.http.legacy"


### PR DESCRIPTION
Allow http links to be opened on webview in the api level 28 which doesnt allow clear text traffic by default